### PR TITLE
Fix require path in ridgepole-ext-tidb.rb

### DIFF
--- a/lib/ridgepole-ext-tidb.rb
+++ b/lib/ridgepole-ext-tidb.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-require_relative 'lib/ridgepole/ext/tidb'
+require_relative 'ridgepole/ext/tidb'


### PR DESCRIPTION
- 修正: lib/ridgepole-ext-tidb.rb の require パスを修正