### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, master ]


### PR DESCRIPTION
Potential fix for [https://github.com/forgxisto/ridgepole-ext-tidb/security/code-scanning/3](https://github.com/forgxisto/ridgepole-ext-tidb/security/code-scanning/3)

Add an explicit top-level `permissions` block to `.github/workflows/test.yml` so all jobs inherit least-privilege token access without changing workflow behavior.

Best fix here: insert at workflow root (after `name` and before `on`) this block:

```yml
permissions:
  contents: read
```

Why this is best:
- Applies consistently to both `test` and `basic-test` jobs.
- Matches CodeQL’s minimal recommended baseline.
- Does not alter existing job logic, matrix, or steps.
- No imports/methods/dependencies are needed for YAML workflow hardening.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
